### PR TITLE
[Feat/#30]  특정 유저의 최근 한달간 커밋수를 보내주는 API 제작

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
     "start": "node ./bin/www"
   },
   "dependencies": {
+    "axios": "^0.21.4",
     "cookie-parser": "^1.4.4",
     "debug": "^2.6.9",
     "dotenv": "^10.0.0",

--- a/backend/src/configs/passport.js
+++ b/backend/src/configs/passport.js
@@ -15,10 +15,13 @@ const githubLoginCallback = async (accessToken, refreshToken, profile, done) => 
         
         if (!user) {
             user = await User.create({
-                githubId
+                githubId,
+                accessToken
             });
-            
-            return done(null, user);
+        }
+        else if (user.accessToken !== accessToken) {
+            user.accessToken = accessToken;
+            await user.save()
         }
         
         return done(null, user);

--- a/backend/src/models/user.js
+++ b/backend/src/models/user.js
@@ -7,6 +7,7 @@ const userSchema = new Schema({
         email: String,
         teamIds: Array,
         githubId : String,
+        accessToken: String
 });
 
 module.exports = mongoose.model('User', userSchema);

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -5,7 +5,8 @@ const router = express.Router();
 
 
 router.get('/github', passport.authenticate("github", {
-  failureRedirect: "/"
+	failureRedirect: "/",
+	scope: [ 'repo', 'user:login' ]
 }))
 
 router.get('/github/callback', 

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -10,7 +10,10 @@ router.get('/github', passport.authenticate("github", {
 }))
 
 router.get('/github/callback', 
-	passport.authenticate('github', { failureRedirect: '/'}),
+	passport.authenticate('github', {
+		failureRedirect: "/",
+		scope: [ 'repo', 'user:login' ]
+	}),
 	(req, res) => {
 		req.session.save(() => {
 			const user = req.user;

--- a/backend/src/routes/user.js
+++ b/backend/src/routes/user.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const userService = require('../services/user.js');
+const githubService = require('../services/github.js');
 
 
 const validateEmail = (email) => {
@@ -25,16 +26,17 @@ const validateNickName = (nickName) => {
 
 router.get('/', (req, res) => {
 	const data = {
-		isLogin: false,
-		user: null,
+		email: null,
+		nickName: null,
+		userId: null
 	};
 	
 	if (req.user) {
 		data.isLogin = true;
 		const {
-			email = null, nickName = null
+			email, nickName, githubId: userId
 		} = req.user;
-		data.user = { email, nickName };
+		data = { email, nickName, userId };
 		
 		res.json(data);
 	}
@@ -72,13 +74,27 @@ router.post('/edit', async (req, res) => {
 	
 	req.login(user, (err) => {
 		if (!err){
-			const data = { email, nickName };
+			const data = { email, nickName, userId: user.githubId };
 			
 			return res.json(data);
 		}
 		
 		res.send(err);
 	});
+})
+
+router.get('/:userId/commits', async (req, res) => {
+	const githubId = req.params.userId;
+	
+	try{
+		const data = await githubService.getCommitCounts(githubId);
+
+		res.json(data);
+	}
+	catch(err) {
+		res.status(400).send(err.message);
+	}
+	
 })
 
 module.exports = router;

--- a/backend/src/services/github.js
+++ b/backend/src/services/github.js
@@ -1,0 +1,79 @@
+const axios = require('axios');
+const User = require('../models/user.js');
+
+const parseDay = (inputDate) => {
+    const year = inputDate.getFullYear();
+    const month = (inputDate.getMonth() + 1).toString().padStart(2, "0");
+    const date = inputDate.getDate().toString().padStart(2, "0");
+    const day = `${year}-${month}-${date}`;
+    
+    return day;
+}
+
+const getCommitCounts = async (githubId) => {
+    const user = await User.findOne({ githubId }).exec();
+    
+    if (!user) {
+        throw new Error("회원가입되지 않은 사용자입니다.");
+    }
+    
+    const repoInfos = await axios.get(`https://api.github.com/user/repos`,{
+        headers: {
+            Authorization: `token ${user.accessToken}`
+        }
+    });
+    
+    const repos = repoInfos.data.map(ele => ele.name);
+    repos.forEach(ele => console.log(ele));
+    
+    const commitInfos = await Promise.all(
+        repos.map(repo => {
+            return axios.get(`https://api.github.com/repos/${githubId}/${repo}/commits`,{
+                headers: {
+                    Authorization: `token ${user.accessToken}`
+                }
+            });
+        })
+    );
+    
+    const commits = {};
+    const today = new Date();
+    
+    new Array(30).fill(0)
+    .forEach((_, index) => {
+        const target = new Date(today);
+        
+        target.setDate(target.getDate() - 29 + index);
+        
+        const day = parseDay(target);
+        
+        commits[day] = 0;
+    })
+    
+    commitInfos.forEach((commitInfo) => {
+        commitInfo.data.forEach(({ commit }) => {
+            const dateString = commit.committer.date;
+            const date = new Date(dateString);
+            
+            const day = parseDay(date);
+            
+            if (commits.hasOwnProperty(day)){
+                commits[day]++;
+            }
+        })
+    });
+    
+    
+    
+    const result = [];
+    for (const key in commits){
+        result.push({day: key, commit: commits[key]});
+    }
+    
+    return result;
+}
+
+
+module.exports = {
+    getCommitCounts
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7774,6 +7774,11 @@ node-releases@^1.1.61, node-releases@^1.1.76:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.76.tgz#df245b062b0cafbd5282ab6792f7dccc2d97f36e"
   integrity sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA==
 
+nodemailer@^6.6.5:
+  version "6.6.5"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.6.5.tgz#f9f6953cee5cfe82cbea152eeddacf7a0442049a"
+  integrity sha512-C/v856DBijUzHcHIgGpQoTrfsH3suKIRAGliIzCstatM2cAa+MYX3LuyCrABiO/cdJTxgBBHXxV1ztiqUwst5A==
+
 nodemon@^2.0.12:
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-2.0.12.tgz#5dae4e162b617b91f1873b3bfea215dd71e144d5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2540,6 +2540,13 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.3.tgz#b55cd8e8ddf659fe89b064680e1c6a4dceab0325"
   integrity sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
 
+axios@^0.21.4:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -5181,7 +5188,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   version "1.14.4"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
   integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==


### PR DESCRIPTION
Github API를 사용하여 특정 유저의 최근 한달간 커밋수를 보내준다.

`GET /user/:userId/commits` 요청으로 해당 유저의 최근 한달간 커밋수를 json으로 받을 수 있다.
json의 형식은 다음과 같다.
`[ { day: "2021-08-25", commit: 5 }, { day: "2021-08-26", commit: 6 }, ..., { day: "2021-09-24", commit: 10 } ]`
배열의 원소는 날짜순으로 정렬되어 있으며, `commit` 속성은 그날의 커밋 수이다.

만약 회원가입되지 않은 사용자의 정보를 가져오려할 경우 400 status Code를 반환한다.