### PR TITLE
[Feat/#42] 스터디 참가 탈퇴 api

### DIFF
--- a/backend/src/models/team.js
+++ b/backend/src/models/team.js
@@ -7,6 +7,7 @@ const teamSchema = new Schema({
         password: String,
         details: String,
         userIds: Array,
+        isLocked: Boolean
 });
 
 module.exports = mongoose.model('Team', teamSchema);

--- a/backend/src/routes/team.js
+++ b/backend/src/routes/team.js
@@ -1,10 +1,14 @@
-const {createTeam, deleteTeam, updateTeam, searchTeams} = require("../services/team/team");
+const {createTeam, deleteTeam, updateTeam, searchTeams, enterTeam, exitTeam} = require("../services/team/team");
 const express = require('express');
 const router = express.Router();
 
 router.get('/',searchTeams);
 
 router.post('/',createTeam);
+
+router.put('/enter', enterTeam);
+
+router.put('/exit', exitTeam);
 
 router.put('/:teamId',updateTeam);
 

--- a/backend/src/services/team/team.js
+++ b/backend/src/services/team/team.js
@@ -93,4 +93,53 @@ const searchTeams = async (req, res, next) => {
     }
 };
 
-module.exports = { createTeam, deleteTeam, updateTeam, searchTeams };
+const enterTeam = async (req,res,next) => {
+    try{
+        const teamId = req.query['teamId'];
+        const userId = req.query['userId'];
+        const team = await Team.findById(teamId);
+        const userIds = [...team.userIds];
+        userIds.push(userId);
+        team.userIds = userIds;
+        team.save();
+        await res.status(200).json({
+            code: '2000',
+            status: '성공 : Team 입장',
+            message: 'User가 Team에 정상적으로 입장하였습니다.'
+        });
+    }
+    catch(err){
+        console.error(err);
+        await res.status(500).json({
+            code: '5000',
+            status: '에러 : 서버 에러',
+            message : `${err}`
+        });
+    }
+};
+
+const exitTeam = async (req,res,next) => {
+    try{
+        const teamId = req.query['teamId'];
+        const userId = req.query['userId'];
+        const team = await Team.findById(teamId);
+        const userIds = [...team.userIds];
+        team.userIds = userIds.filter(el => el !== userId);
+        team.save();
+        await res.status(200).json({
+            code: '2000',
+            status: '성공 : Team 퇴장',
+            message: 'User가 Team에 정상적으로 퇴장하였습니다.'
+        });
+    }
+    catch(err){
+        console.error(err);
+        await res.status(500).json({
+            code: '5000',
+            status: '에러 : 서버 에러',
+            message : `${err}`
+        });
+    }
+};
+
+module.exports = { createTeam, deleteTeam, updateTeam, searchTeams, enterTeam, exitTeam };


### PR DESCRIPTION
스터디 참가 PUT /study/enter?userId=${userId}&&teamId=${teamId}
스터디 탈퇴 PUT /study/exit?userId=${userId}&&teamId=${teamId}
스터디 참가와 탈퇴는 team에 있는 userIds를 조작한다.
따로 반환하는 값이 없기 때문에, reload 하는 것이 필요할 듯!
따로 필요한 값이 있으면 말씀해주세요
response
{
  "code": "2000",
  "status": "성공 : Team 입장",
  "message": "User가 Team에 정상적으로 입장하였습니다."
}