### PR TITLE
[feat/#30] 요청받은 그룹의 모든 참가자의 당일 커밋수를 보내주는 api 제작

### DIFF
--- a/backend/src/routes/team.js
+++ b/backend/src/routes/team.js
@@ -1,5 +1,7 @@
 const {createTeam, deleteTeam, updateTeam, searchTeams, enterTeam, exitTeam} = require("../services/team/team");
 const express = require('express');
+const githubService = require('../services/github.js');
+
 const router = express.Router();
 
 router.get('/',searchTeams);
@@ -13,5 +15,13 @@ router.put('/exit', exitTeam);
 router.put('/:teamId',updateTeam);
 
 router.delete('/:teamId',deleteTeam);
+
+router.get('/:teamId/commits', async (req, res) => {
+    const teamId = req.params.teamId;
+    
+    const data = await githubService.getCommitCountOfTeam(teamId);
+    
+    res.json(data);
+})
 
 module.exports = router;

--- a/backend/src/routes/user.js
+++ b/backend/src/routes/user.js
@@ -87,7 +87,7 @@ router.get('/:userId/commits', async (req, res) => {
 	const githubId = req.params.userId;
 	
 	try{
-		const data = await githubService.getCommitCounts(githubId);
+		const data = await githubService.getCommitCountsForMonth(githubId);
 
 		res.json(data);
 	}

--- a/backend/src/services/github.js
+++ b/backend/src/services/github.js
@@ -1,5 +1,7 @@
 const axios = require('axios');
 const User = require('../models/user.js');
+const Team = require('../models/team.js');
+
 
 const parseDay = (inputDate) => {
     const year = inputDate.getFullYear();
@@ -10,70 +12,105 @@ const parseDay = (inputDate) => {
     return day;
 }
 
-const getCommitCounts = async (githubId) => {
+const getCommits = async ({ githubId, accessToken, since }) => {
+    const repoInfos = await axios.get(`https://api.github.com/user/repos`,{
+        headers: {
+            Authorization: `token ${accessToken}`
+        }
+    });
+    
+    const repos = repoInfos.data.map(ele => ele.name);
+    
+    const commitInfos = await Promise.all(
+        repos.map(repo => {
+            return axios.get(`https://api.github.com/repos/${githubId}/${repo}/commits`,{
+                headers: {
+                    Authorization: `token ${accessToken}`
+                },
+                params: {
+                    since
+                }
+            });
+        })
+    );
+    
+    const commits = commitInfos.flatMap(commitInfo => commitInfo.data.flatMap(ele => ele.commit));
+    
+    return commits;
+}
+
+const getCommitCountsForMonth = async (githubId) => {
     const user = await User.findOne({ githubId }).exec();
     
     if (!user) {
         throw new Error("회원가입되지 않은 사용자입니다.");
     }
     
-    const repoInfos = await axios.get(`https://api.github.com/user/repos`,{
-        headers: {
-            Authorization: `token ${user.accessToken}`
-        }
-    });
-    
-    const repos = repoInfos.data.map(ele => ele.name);
-    repos.forEach(ele => console.log(ele));
-    
-    const commitInfos = await Promise.all(
-        repos.map(repo => {
-            return axios.get(`https://api.github.com/repos/${githubId}/${repo}/commits`,{
-                headers: {
-                    Authorization: `token ${user.accessToken}`
-                }
-            });
-        })
-    );
-    
-    const commits = {};
+    const commitCounter = {};
     const today = new Date();
+    const dayBeforeMonth = new Date(today);
+    dayBeforeMonth.setDate(dayBeforeMonth.getDate() - 30);
     
     new Array(30).fill(0)
     .forEach((_, index) => {
-        const target = new Date(today);
+        const target = new Date(dayBeforeMonth);
         
-        target.setDate(target.getDate() - 29 + index);
+        target.setDate(target.getDate() + index + 1);
         
         const day = parseDay(target);
         
-        commits[day] = 0;
+        commitCounter[day] = 0;
     })
     
-    commitInfos.forEach((commitInfo) => {
-        commitInfo.data.forEach(({ commit }) => {
-            const dateString = commit.committer.date;
-            const date = new Date(dateString);
-            
-            const day = parseDay(date);
-            
-            if (commits.hasOwnProperty(day)){
-                commits[day]++;
-            }
-        })
-    });
     
+    const commits = await getCommits({ githubId, accessToken: user.accessToken, since: dayBeforeMonth.toISOString() });
+    commits.forEach(commit => {
+        const dateString = commit.committer.date;
+        const date = new Date(dateString);
+        
+        const day = parseDay(date);
+        
+        if (commitCounter.hasOwnProperty(day)){
+            commitCounter[day]++;
+        }
+    })
     
     
     const result = [];
-    for (const key in commits){
-        result.push({day: key, commit: commits[key]});
+    for (const key in commitCounter){
+        result.push({day: key, commit: commitCounter[key]});
     }
     
     return result;
 }
 
+const getCommitCountOfTeam = async (teamId) => {
+    const team = await Team.findById(teamId).exec();
+    const { userIds } = team;
+    
+    const since = new Date();
+    since.setDate(since.getDate() - 1);
+    
+    
+    const commits = await Promise.all(
+        userIds.map(async userId => {
+            const user = await User.findOne({ githubId: userId }).exec();
+            
+            if (!user){
+                return 0;
+            }
+            const { githubId, accessToken } = user;
+            
+            const commits = await getCommits({ githubId, accessToken, since });
+            
+            return {userId: userId, commit: commits.length};
+        })
+    );
+    
+    return commits;
+}
 
 module.exports = {
-    getCommitCounts
+    getCommitCountsForMonth,
+    getCommitCountOfTeam
 }


### PR DESCRIPTION
`GET /study/:teamId/commits`로 오쳥을 보낼 수 있다.
`teamId` 그룹의 참가자들의 당일 커밋수를 담은 배열을 json으로 보내준다.

json 형식은 다음과 같다.
`[ { userId: String, commit: Integar } ]`
- userId : 참가자의 githubId
- commit : 해당 유저의 당일 커밋 수