### PR TITLE
백엔드 서버의 버그 수정

### DIFF
--- a/backend/src/services/github.js
+++ b/backend/src/services/github.js
@@ -24,21 +24,28 @@ const getCommits = async ({ githubId, accessToken, since }) => {
             Authorization: `token ${accessToken}`
         }
     });
-    const repos = repoInfos.data.map(ele => ele.name);
+	const repos = repoInfos.data.map(ele => ele.full_name);
     
     
-    const commitInfos = await Promise.all(
+    const commitInfos = (await Promise.all(
         repos.map(repo => {
-            return axios.get(`https://api.github.com/repos/${githubId}/${repo}/commits`,{
-                headers: {
-                    Authorization: `token ${accessToken}`
-                },
-                params: {
-                    since
-                }
-            });
+            const link = `https://api.github.com/repos/${repo}/commits`
+            try {
+                return axios.get(link,{
+                    headers: {
+                        Authorization: `token ${accessToken}`
+                    },
+                    params: {
+                        since
+                    }
+                });
+            }
+            catch (err) {
+                return null;
+            }
         })
-    );
+    )).filter(ele => ele);
+    
     const commits = commitInfos.flatMap(commitInfo => commitInfo.data.flatMap(ele => ele.commit));
     
     return commits;

--- a/backend/src/services/github.js
+++ b/backend/src/services/github.js
@@ -65,6 +65,7 @@ const getCommitCountsForMonth = async (githubId) => {
     const commitCounter = {};
     const dayBeforeMonth = new Date();
     dayBeforeMonth.setDate(dayBeforeMonth.getDate() - 30);
+    dayBeforeMonth.setHours(dayBeforeMonth.getHours() + 9);
     
     new Array(30).fill(0)
     .forEach((_, index) => {
@@ -112,6 +113,7 @@ const getCommitCountOfTeam = async (teamId) => {
     
     const since = new Date();
     since.setDate(since.getDate() - 1);
+    since.setHours(since.getHours() + 9);
     
     const commits = await Promise.all(
         userIds.map(async userId => {
@@ -122,7 +124,7 @@ const getCommitCountOfTeam = async (teamId) => {
             
             const { githubId, accessToken } = user;
             
-            const commits = await getCommits({ githubId, accessToken, since });
+            const commits = await getCommits({ githubId, accessToken, since: since.toISOString() });
             
             return {userId: userId, commit: commits.length};
         })

--- a/backend/src/services/team/team.js
+++ b/backend/src/services/team/team.js
@@ -74,7 +74,11 @@ const searchTeams = async (req, res, next) => {
         let teams;
 
         if(title !== undefined && userId === undefined) teams = await Team.find({title:  new RegExp(`${title}`,'i')}).exec();
-        else if(title === undefined && userId !== undefined) teams = await Team.find({userIds : [`${userId}`]}).exec();
+        else if(title === undefined && userId !== undefined) {
+            teams = await Team.find()
+                              .where('userIds').in([`${userId}`])
+                              .exec();
+        }
         else if(title === undefined && userId === undefined) teams = await Team.find({});
         else{
             throw new Error("query로 보내는 변수가 잘못되었습니다.");

--- a/backend/src/services/team/team.js
+++ b/backend/src/services/team/team.js
@@ -105,7 +105,7 @@ const enterTeam = async (req,res,next) => {
     try{
         const teamId = req.query['teamId'];
         const userId = req.query['userId'];
-        const team = await Team.findById(teamId);
+        const team = await Team.findById(teamId).exec();
         if(team.password !== null && team.password !== req.body.password) throw new Error("비밀번호가 일치하지 않습니다.");
         const userIds = [...team.userIds];
         userIds.push(userId);

--- a/package.json
+++ b/package.json
@@ -7,5 +7,11 @@
   "workspaces": [
     "frontend",
     "backend"
-  ]
+  ],
+  "scripts": {
+    "build": "cd ./frontend && yarn build",
+    
+    "prestart": "yarn build",
+    "start": "cd ./backend && yarn start"
+  }
 }


### PR DESCRIPTION
Github API를 사용하는 코드에서 발생한 버그들을 수정함
- 다른 사람들의 레포지토리에 수행한 커밋들도 가져오도록 수정
- 타임존이 UTC시간으로 설정되어, 적절하지 않은 시간의 커밋을 가져오는 버그를 수정

스터디방을 제대로 가져오지 못하던 버그를 수정함
- mongoDB의 배열타입 필드의 값을 `in` 연산자를 통해 검사하도록 수정함
- mongoose 함수의 잘못된 사용을 수정함